### PR TITLE
feat: add saved recipe and activity tabs, implement saved recipe and …

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-firestore")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.9.0")
-    implementation(platform("io.github.jan-tennert.supabase:bom:3.1.0-beta-2"))
+    implementation(platform("io.github.jan-tennert.supabase:bom:3.1.0"))
     implementation("io.github.jan-tennert.supabase:storage-kt")
     implementation("io.ktor:ktor-client-android:3.0.3")
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0")

--- a/app/src/main/java/com/example/recipefinder/MainActivity.kt
+++ b/app/src/main/java/com/example/recipefinder/MainActivity.kt
@@ -6,6 +6,8 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation.compose.rememberNavController
 import com.example.recipefinder.data.worker.GetRandomRecipesWorker
 import com.example.recipefinder.ui.MainScreen
@@ -15,9 +17,12 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-//        enableEdgeToEdge(
-//            statusBarStyle = SystemBarStyle.light(Color.WHITE, Color.WHITE)
-//        )
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        val insetsController = WindowInsetsControllerCompat(window, window.decorView)
+        insetsController.isAppearanceLightStatusBars = true
+        insetsController.isAppearanceLightNavigationBars = true
+        window.statusBarColor = android.graphics.Color.TRANSPARENT
+        window.navigationBarColor = android.graphics.Color.TRANSPARENT
         super.onCreate(savedInstanceState)
         setContent {
             RecipeFinderTheme {

--- a/app/src/main/java/com/example/recipefinder/MainActivity.kt
+++ b/app/src/main/java/com/example/recipefinder/MainActivity.kt
@@ -1,14 +1,14 @@
 package com.example.recipefinder
 
-import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
 import com.example.recipefinder.data.worker.GetRandomRecipesWorker
-import com.example.recipefinder.ui.navigation.RecipeFinderNavGraph
+import com.example.recipefinder.ui.MainScreen
 import com.example.recipefinder.ui.theme.RecipeFinderTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -21,8 +21,12 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             RecipeFinderTheme {
-                val navController = rememberNavController()
-                RecipeFinderNavGraph(navController)
+                Surface(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    val navController = rememberNavController()
+                    MainScreen(navController = navController)
+                }
             }
         }
         // TODO: commented out for now, there are random recipes in the datastore

--- a/app/src/main/java/com/example/recipefinder/data/model/CommunityPost.kt
+++ b/app/src/main/java/com/example/recipefinder/data/model/CommunityPost.kt
@@ -1,5 +1,6 @@
 package com.example.recipefinder.data.model
 
+import com.google.firebase.firestore.DocumentSnapshot
 import java.util.UUID
 
 data class CommunityPost(
@@ -12,3 +13,21 @@ data class CommunityPost(
     val like: Int,
     val postId: String = UUID.randomUUID().toString()
 )
+
+fun DocumentSnapshot.toCommunityPost(): CommunityPost? {
+    return try {
+        CommunityPost(
+            timestamp = getLong("timestamp") ?: 0L,
+            post = getString("post") ?: "",
+            userName = getString("userName") ?: "",
+            userProfileImageUrl = getString("userProfileImageUrl") ?: "",
+            recipeImageUrl = getString("recipeImageUrl") ?: "",
+            recipeTitle = getString("recipeTitle") ?: "",
+            like = getLong("like")?.toInt() ?: 0,
+            postId = getString("postId") ?: "",
+        )
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
+}

--- a/app/src/main/java/com/example/recipefinder/data/repository/community/CommunityRepository.kt
+++ b/app/src/main/java/com/example/recipefinder/data/repository/community/CommunityRepository.kt
@@ -1,7 +1,9 @@
 package com.example.recipefinder.data.repository.community
 
 import android.net.Uri
+import com.example.recipefinder.data.model.CommunityPost
 
 interface CommunityRepository {
     suspend fun postRecipe(post: String, recipeTitle: String, recipeImageUri: Uri)
+    suspend fun getCommunityPosts(): List<CommunityPost>
 }

--- a/app/src/main/java/com/example/recipefinder/data/repository/community/CommunityRepositoryImpl.kt
+++ b/app/src/main/java/com/example/recipefinder/data/repository/community/CommunityRepositoryImpl.kt
@@ -45,6 +45,7 @@ class CommunityRepositoryImpl @Inject constructor(
                 .add(communityPost)
         } catch (e: Exception) {
             e.printStackTrace()
+            throw Exception("Failed to post recipe")
         }
     }
 
@@ -54,7 +55,8 @@ class CommunityRepositoryImpl @Inject constructor(
     ): String? {
         return withContext(Dispatchers.IO) {
             val inputStream =
-                context.contentResolver.openInputStream(imageUri) ?: throw Exception("Recipe image URI is invalid")
+                context.contentResolver.openInputStream(imageUri)
+                    ?: throw Exception("Recipe image URI is invalid")
             val byteArray = inputStream.readBytes()
             val fileName = "community_recipes/posts_images/$title.jpg"
             supabase.storage.from("RecipeFinder").upload(fileName, byteArray)

--- a/app/src/main/java/com/example/recipefinder/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/MainScreen.kt
@@ -55,6 +55,9 @@ fun MainScreen(
             }
         }
     ) { padding ->
-        RecipeFinderNavGraph(navController)
+        RecipeFinderNavGraph(
+            paddingValues = padding,
+            navController = navController
+        )
     }
 }

--- a/app/src/main/java/com/example/recipefinder/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/MainScreen.kt
@@ -1,0 +1,60 @@
+package com.example.recipefinder.ui
+
+import android.annotation.SuppressLint
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import com.example.recipefinder.ui.home.components.BottomNavigationBar
+import com.example.recipefinder.ui.navigation.RecipeFinderDestinations.COMMUNITY_ROUTE
+import com.example.recipefinder.ui.navigation.RecipeFinderDestinations.HOME_ROUTE
+import com.example.recipefinder.ui.navigation.RecipeFinderDestinations.PROFILE_ROUTE
+import com.example.recipefinder.ui.navigation.RecipeFinderNavGraph
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun MainScreen(
+    navController: NavHostController
+) {
+    Scaffold(
+        bottomBar = {
+            BottomAppBar {
+                BottomNavigationBar {
+                    if (it == "Profile") {
+                        navController.navigate(PROFILE_ROUTE) {
+                            navController.graph.startDestinationRoute?.let { screen_route ->
+                                popUpTo(screen_route) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        }
+                    } else if (it == "Home") {
+                        navController.navigate(HOME_ROUTE) {
+                            navController.graph.startDestinationRoute?.let { screen_route ->
+                                popUpTo(screen_route) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        }
+                    } else if (it == "Community") {
+                        navController.navigate(COMMUNITY_ROUTE) {
+                            navController.graph.startDestinationRoute?.let { screen_route ->
+                                popUpTo(screen_route) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ) { padding ->
+        RecipeFinderNavGraph(navController)
+    }
+}

--- a/app/src/main/java/com/example/recipefinder/ui/community/CommunityScreen.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/community/CommunityScreen.kt
@@ -1,12 +1,20 @@
 package com.example.recipefinder.ui.community
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.recipefinder.data.model.CommunityPost
@@ -24,23 +33,34 @@ import com.example.recipefinder.ui.community.elements.CommunityPostItem
 
 @Composable
 fun CommunityScreen(
-    viewmodel: CommunityScreenViewModel = hiltViewModel()
+    paddingValues: PaddingValues,
+    viewmodel: CommunityScreenViewModel = hiltViewModel(),
+    onPostClick: () -> Unit
 ) {
     val state by viewmodel.communityPosts.collectAsStateWithLifecycle()
-
+    CommunityScreenContent(paddingValues, emptyList()) {
+        onPostClick()
+    }
     when (state) {
         is CommunityScreenState.Error -> {}
         CommunityScreenState.Loading -> {}
         is CommunityScreenState.Success -> {
             val posts = (state as CommunityScreenState.Success).posts
-            CommunityScreenContent(posts)
+            CommunityScreenContent(paddingValues, posts) {
+                onPostClick()
+            }
         }
     }
 }
 
 @Composable
-private fun CommunityScreenContent(posts: List<CommunityPost>) {
+private fun CommunityScreenContent(
+    paddingValues: PaddingValues,
+    posts: List<CommunityPost>,
+    onPostClick: () -> Unit
+) {
     Scaffold(
+        modifier = Modifier.padding(paddingValues),
         topBar = {
             Text(
                 textAlign = TextAlign.Center,
@@ -51,6 +71,25 @@ private fun CommunityScreenContent(posts: List<CommunityPost>) {
                 fontWeight = FontWeight.Bold,
                 color = Color.Black,
                 text = "Our Community"
+            )
+        },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                containerColor = MaterialTheme.colorScheme.primary,
+                onClick = { onPostClick() },
+                icon = { Icon(Icons.Filled.Add, "Post") },
+                text = {
+                    Text(
+                        text = "Post",
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 12.sp,
+                        color = Color.White
+                    )
+                },
+                shape = RoundedCornerShape(32.dp),
+                modifier = Modifier
+                    .height(50.dp)
+                    .navigationBarsPadding()
             )
         }
     ) { paddingValues ->
@@ -120,6 +159,9 @@ fun PreviewCommunityScreen() {
         )
     )
     CommunityScreenContent(
+        paddingValues = PaddingValues(20.dp),
         posts = dummyPosts
-    )
+    ) {
+
+    }
 }

--- a/app/src/main/java/com/example/recipefinder/ui/community/CommunityScreen.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/community/CommunityScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -38,9 +39,6 @@ fun CommunityScreen(
     onPostClick: () -> Unit
 ) {
     val state by viewmodel.communityPosts.collectAsStateWithLifecycle()
-    CommunityScreenContent(paddingValues, emptyList()) {
-        onPostClick()
-    }
     when (state) {
         is CommunityScreenState.Error -> {}
         CommunityScreenState.Loading -> {}
@@ -66,8 +64,8 @@ private fun CommunityScreenContent(
                 textAlign = TextAlign.Center,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(50.dp)
-                    .padding(vertical = 16.dp),
+                    .padding(vertical = 16.dp)
+                    .wrapContentHeight(),
                 fontWeight = FontWeight.Bold,
                 color = Color.Black,
                 text = "Our Community"

--- a/app/src/main/java/com/example/recipefinder/ui/community/CommunityScreenViewModel.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/community/CommunityScreenViewModel.kt
@@ -3,6 +3,7 @@ package com.example.recipefinder.ui.community
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.recipefinder.data.model.CommunityPost
+import com.example.recipefinder.data.repository.community.CommunityRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,7 +18,7 @@ sealed class CommunityScreenState {
 
 @HiltViewModel
 class CommunityScreenViewModel @Inject constructor(
-
+    private val communityRepository: CommunityRepository
 ) : ViewModel() {
 
     private val _communityPosts =
@@ -28,8 +29,10 @@ class CommunityScreenViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             try {
-
+                _communityPosts.value =
+                    CommunityScreenState.Success(communityRepository.getCommunityPosts())
             } catch (e: Exception) {
+                _communityPosts.value = CommunityScreenState.Error(e.message ?: "Unknown error")
                 e.printStackTrace()
             }
         }

--- a/app/src/main/java/com/example/recipefinder/ui/community/elements/CommunityPostItem.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/community/elements/CommunityPostItem.kt
@@ -52,7 +52,7 @@ fun CommunityPostItem(
         ) {
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data(R.drawable.ic_launcher_background)
+                    .data(if (post.recipeImageUrl.isEmpty()) R.drawable.ic_launcher_background else post.recipeImageUrl)
                     .build(),
                 contentDescription = "",
                 modifier = Modifier
@@ -62,7 +62,9 @@ fun CommunityPostItem(
             )
 
             Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 // TODO: user profile pic url
@@ -97,7 +99,9 @@ fun CommunityPostItem(
                 text = post.post
             )
             Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(

--- a/app/src/main/java/com/example/recipefinder/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/home/HomeScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.recipefinder.data.model.Recipe
-import com.example.recipefinder.ui.home.components.BottomNavigationBar
 import com.example.recipefinder.ui.home.components.LottieLoadingIndicator
 import com.example.recipefinder.ui.home.elements.RecipeHorizontalListItem
 import com.example.recipefinder.ui.home.elements.TopContainer
@@ -43,11 +42,8 @@ fun Home(
 fun HomeContent(
     onRecipeClick: (Int) -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
-    onBottomBarClick: (String) -> Unit,
 ) {
-    Scaffold(
-        bottomBar = { BottomNavigationBar(onBottomBarClick) }
-    ) { paddingValues ->
+    Scaffold { paddingValues ->
         val homeState by viewModel.homeState.collectAsStateWithLifecycle()
         Column(
             modifier = Modifier
@@ -124,9 +120,10 @@ fun HomeContent(
                         }
                         item {
                             if (list3.isNotEmpty()) {
-                                HorizontalList(getLikesForRecipe = {
-                                    viewModel.getRecipeLike(it)
-                                }, onRecipeClick,
+                                HorizontalList(
+                                    getLikesForRecipe = {
+                                        viewModel.getRecipeLike(it)
+                                    }, onRecipeClick,
                                     onSave = { viewModel.save(it) }, "Holiday!", list3
                                 )
                             }

--- a/app/src/main/java/com/example/recipefinder/ui/home/components/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/home/components/BottomNavigationBar.kt
@@ -2,6 +2,7 @@ package com.example.recipefinder.ui.home.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.ModeComment
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -26,6 +27,7 @@ fun BottomNavigationBar(onBottomBarClick: (String) -> Unit) {
     var selectedItemIndex by rememberSaveable { mutableStateOf(0) }
     val items = listOf(
         BottomNavigationItem(title = "Home", selectedIcon = Icons.Default.Home),
+        BottomNavigationItem(title = "Community", selectedIcon = Icons.Default.ModeComment),
         BottomNavigationItem(title = "Profile", selectedIcon = Icons.Default.Person)
     )
     NavigationBar(

--- a/app/src/main/java/com/example/recipefinder/ui/navigation/RecipeFinderNavGraph.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/navigation/RecipeFinderNavGraph.kt
@@ -1,5 +1,6 @@
 package com.example.recipefinder.ui.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -8,6 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.example.recipefinder.ui.community.CommunityScreen
 import com.example.recipefinder.ui.home.HomeContent
+import com.example.recipefinder.ui.post.PostRecipeScreen
 import com.example.recipefinder.ui.profile.components.ProfileScreen
 import com.example.recipefinder.ui.recipedetails.RecipeDetailsScreen
 import com.example.recipefinder.ui.recipetipdetails.RecipeTipDetailsScreen
@@ -15,6 +17,7 @@ import com.example.recipefinder.ui.recipetipdetails.RecipeTipDetailsScreen
 // TODO: fix bottom nav
 @Composable
 fun RecipeFinderNavGraph(
+    paddingValues: PaddingValues,
     navController: NavHostController,
     startDestination: String = RecipeFinderDestinations.HOME_ROUTE,
 ) {
@@ -36,7 +39,21 @@ fun RecipeFinderNavGraph(
         composable(
             route = RecipeFinderDestinations.COMMUNITY_ROUTE
         ) {
-            CommunityScreen()
+            CommunityScreen(
+                paddingValues
+            ) {
+                navigationActions.navigateToPostRecipeScreen()
+            }
+        }
+
+        composable(
+            route = RecipeFinderDestinations.POST_RECIPE_ROUTE
+        ) {
+            PostRecipeScreen(
+                paddingValues
+            ) {
+                navigationActions.popCurrentDestination()
+            }
         }
 
         composable(

--- a/app/src/main/java/com/example/recipefinder/ui/navigation/RecipeFinderNavGraph.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/navigation/RecipeFinderNavGraph.kt
@@ -5,8 +5,8 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.example.recipefinder.ui.community.CommunityScreen
 import com.example.recipefinder.ui.home.HomeContent
 import com.example.recipefinder.ui.profile.components.ProfileScreen
 import com.example.recipefinder.ui.recipedetails.RecipeDetailsScreen
@@ -15,7 +15,7 @@ import com.example.recipefinder.ui.recipetipdetails.RecipeTipDetailsScreen
 // TODO: fix bottom nav
 @Composable
 fun RecipeFinderNavGraph(
-    navController: NavHostController = rememberNavController(),
+    navController: NavHostController,
     startDestination: String = RecipeFinderDestinations.HOME_ROUTE,
 ) {
 
@@ -30,14 +30,13 @@ fun RecipeFinderNavGraph(
         ) {
             HomeContent(
                 onRecipeClick = { navigationActions.navigateToRecipeDetailsScreen(it) },
-                onBottomBarClick = {
-                    if (it == "Profile") {
-                        navController.navigate(RecipeFinderDestinations.PROFILE_ROUTE)
-                    } else {
-                        navController.navigate(RecipeFinderDestinations.HOME_ROUTE)
-                    }
-                },
             )
+        }
+
+        composable(
+            route = RecipeFinderDestinations.COMMUNITY_ROUTE
+        ) {
+            CommunityScreen()
         }
 
         composable(
@@ -45,13 +44,6 @@ fun RecipeFinderNavGraph(
         ) {
             ProfileScreen(
                 onRecipeClick = { navigationActions.navigateToRecipeDetailsScreen(it) },
-                onBottomBarClick = {
-                    if (it == "Profile") {
-                        navController.navigate(RecipeFinderDestinations.PROFILE_ROUTE)
-                    } else {
-                        navController.navigate(RecipeFinderDestinations.HOME_ROUTE)
-                    }
-                }
             )
         }
 

--- a/app/src/main/java/com/example/recipefinder/ui/navigation/RecipeFinderNavigation.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/navigation/RecipeFinderNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavController
 object RecipeFinderDestinations {
     const val HOME_ROUTE = "home_route"
     const val PROFILE_ROUTE = "profile_route"
+    const val COMMUNITY_ROUTE = "community_route"
     const val RECIPE_DETAILS_ROUTE = "recipe_details_route"
     const val RECIPE_TIP_DETAILS_ROUTE = "recipe_tip_details_route"
     const val MAKE_RECIPE_TIP_ROUTE = "make_recipe_tip_route"

--- a/app/src/main/java/com/example/recipefinder/ui/navigation/RecipeFinderNavigation.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/navigation/RecipeFinderNavigation.kt
@@ -7,6 +7,7 @@ object RecipeFinderDestinations {
     const val HOME_ROUTE = "home_route"
     const val PROFILE_ROUTE = "profile_route"
     const val COMMUNITY_ROUTE = "community_route"
+    const val POST_RECIPE_ROUTE = "post_recipe_route"
     const val RECIPE_DETAILS_ROUTE = "recipe_details_route"
     const val RECIPE_TIP_DETAILS_ROUTE = "recipe_tip_details_route"
     const val MAKE_RECIPE_TIP_ROUTE = "make_recipe_tip_route"
@@ -36,6 +37,12 @@ class RecipeFinderNavigation(
 
     val popCurrentDestination: () -> Unit = {
         navController.popBackStack()
+    }
+
+    val navigateToPostRecipeScreen: () -> Unit = {
+        navController.navigate(RecipeFinderDestinations.POST_RECIPE_ROUTE) {
+            launchSingleTop = false
+        }
     }
 
 }

--- a/app/src/main/java/com/example/recipefinder/ui/post/PostRecipeScreen.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/post/PostRecipeScreen.kt
@@ -1,0 +1,177 @@
+package com.example.recipefinder.ui.post
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.rememberAsyncImagePainter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostRecipeScreen(
+    paddingValues: PaddingValues,
+    onBackClick: () -> Unit
+) {
+    val title = remember { mutableStateOf("") }
+    val description = remember { mutableStateOf("") }
+    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
+    var addPhotoEnabled by remember { mutableStateOf<Boolean>(true) }
+
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        selectedImageUri = uri
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Share your recipe") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { onBackClick() },
+                    ) {
+                        Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        modifier = Modifier.padding(paddingValues)
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column {
+                OutlinedTextField(
+                    value = title.value,
+                    onValueChange = { title.value = it },
+                    label = { Text("Recipe Title") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                OutlinedTextField(
+                    value = description.value,
+                    onValueChange = { description.value = it },
+                    label = { Text("Recipe Description") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                if (addPhotoEnabled) {
+                    OutlinedButton(
+                        onClick = { photoPickerLauncher.launch("image/*") },
+                    ) {
+                        Text("Add Photo")
+                    }
+                }
+
+                selectedImageUri?.let {
+                    addPhotoEnabled = false
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Box(
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        Image(
+                            painter = rememberAsyncImagePainter(selectedImageUri),
+                            contentDescription = "Selected Photo",
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(RoundedCornerShape(8.dp))
+                                .border(
+                                    width = 1.dp,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    shape = RoundedCornerShape(8.dp)
+                                )
+                        )
+                        IconButton(
+                            onClick = {
+                                addPhotoEnabled = true
+                                selectedImageUri = null
+                            },
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(8.dp)
+                        ) {
+                            Icon(
+                                tint = MaterialTheme.colorScheme.primary,
+                                imageVector = Icons.Default.Cancel,
+                                contentDescription = "Back"
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+            }
+
+            Button(
+                onClick = { },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                shape = RectangleShape,
+                enabled = title.value.isNotEmpty() && description.value.isNotEmpty(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Text("POST RECIPE")
+            }
+        }
+    }
+
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewPostRecipeScreen() {
+    PostRecipeScreen(
+        paddingValues = PaddingValues(0.dp)
+    ) {}
+}

--- a/app/src/main/java/com/example/recipefinder/ui/post/PostRecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/post/PostRecipeViewModel.kt
@@ -33,8 +33,7 @@ class PostRecipeViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 _postState.value = PostRecipeScreenState.Posting
-                //communityRepository.postRecipe(post, recipeTitle, recipeImageUri)
-                delay(2000)
+                communityRepository.postRecipe(post, recipeTitle, recipeImageUri)
                 _postState.value = PostRecipeScreenState.PostSuccess
                 delay(2000)
                 _postState.value = PostRecipeScreenState.Idle

--- a/app/src/main/java/com/example/recipefinder/ui/post/PostRecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/post/PostRecipeViewModel.kt
@@ -1,0 +1,46 @@
+package com.example.recipefinder.ui.post
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.recipefinder.data.repository.community.CommunityRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+
+sealed class PostRecipeScreenState {
+    object Posting : PostRecipeScreenState()
+    object Idle : PostRecipeScreenState()
+    object PostSuccess : PostRecipeScreenState()
+    data class Error(val message: String) : PostRecipeScreenState()
+}
+
+@HiltViewModel
+class PostRecipeViewModel @Inject constructor(
+    private val communityRepository: CommunityRepository,
+) : ViewModel() {
+
+    private val _postState =
+        MutableStateFlow<PostRecipeScreenState>(PostRecipeScreenState.Idle)
+
+    val postState = _postState.asStateFlow()
+
+    fun postRecipe(post: String, recipeTitle: String, recipeImageUri: Uri) {
+        viewModelScope.launch {
+            try {
+                _postState.value = PostRecipeScreenState.Posting
+                //communityRepository.postRecipe(post, recipeTitle, recipeImageUri)
+                delay(2000)
+                _postState.value = PostRecipeScreenState.PostSuccess
+                delay(2000)
+                _postState.value = PostRecipeScreenState.Idle
+            } catch (e: Exception) {
+                _postState.value = PostRecipeScreenState.Error(e.message.toString())
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/recipefinder/ui/profile/components/ProfileScreen.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/profile/components/ProfileScreen.kt
@@ -46,7 +46,6 @@ import coil3.compose.AsyncImage
 import com.example.recipefinder.R
 import com.example.recipefinder.data.model.Recipe
 import com.example.recipefinder.ui.home.HorizontalList
-import com.example.recipefinder.ui.home.components.BottomNavigationBar
 import com.example.recipefinder.ui.home.elements.RecipeHorizontalListItem
 import com.example.recipefinder.ui.myiconpack.MyIconPack
 import com.example.recipefinder.ui.myiconpack.Wave
@@ -56,15 +55,12 @@ import com.example.recipefinder.ui.myiconpack.Wave
 fun ProfileScreen(
     viewmodel: ProfileScreenViewModel = hiltViewModel(),
     onRecipeClick: (Int) -> Unit,
-    onBottomBarClick: (String) -> Unit,
 ) {
     val bookmarkedRecipes = viewmodel.profileState.collectAsStateWithLifecycle()
     var selectedTabIndex by remember { mutableIntStateOf(0) }
     val tabs = listOf("Saved Recipe", "Activity")
 
-    Scaffold(
-        bottomBar = { BottomNavigationBar(onBottomBarClick) }
-    ) { paddingValues ->
+    Scaffold { paddingValues ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -212,7 +208,9 @@ fun ActivityScreen(
                 )
                 if (myRatings.isEmpty()) {
                     Column(
-                        modifier = Modifier.fillMaxWidth().size(100.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .size(100.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
@@ -240,7 +238,9 @@ fun ActivityScreen(
             )
             if (myTips.isEmpty()) {
                 Column(
-                    modifier = Modifier.fillMaxWidth().size(100.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .size(100.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {

--- a/app/src/main/java/com/example/recipefinder/ui/profile/components/ProfileScreen.kt
+++ b/app/src/main/java/com/example/recipefinder/ui/profile/components/ProfileScreen.kt
@@ -10,13 +10,25 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Book
+import androidx.compose.material.icons.filled.ThumbUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,9 +44,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.example.recipefinder.R
-import com.example.recipefinder.ui.myiconpack.MyIconPack
+import com.example.recipefinder.data.model.Recipe
+import com.example.recipefinder.ui.home.HorizontalList
 import com.example.recipefinder.ui.home.components.BottomNavigationBar
 import com.example.recipefinder.ui.home.elements.RecipeHorizontalListItem
+import com.example.recipefinder.ui.myiconpack.MyIconPack
 import com.example.recipefinder.ui.myiconpack.Wave
 
 // TODO: fix the bottom nav
@@ -45,6 +59,8 @@ fun ProfileScreen(
     onBottomBarClick: (String) -> Unit,
 ) {
     val bookmarkedRecipes = viewmodel.profileState.collectAsStateWithLifecycle()
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    val tabs = listOf("Saved Recipe", "Activity")
 
     Scaffold(
         bottomBar = { BottomNavigationBar(onBottomBarClick) }
@@ -69,7 +85,9 @@ fun ProfileScreen(
             )
 
             Column(
-                modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
 
@@ -98,13 +116,19 @@ fun ProfileScreen(
                     )
                 }
 
-
-                Text(
-                    text = "Saved Recipes",
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 14.sp,
-                    modifier = Modifier.padding(bottom = 8.dp)
-                )
+                TabRow(
+                    selectedTabIndex = selectedTabIndex,
+                    backgroundColor = Color.White,
+                    contentColor = MaterialTheme.colorScheme.primary
+                ) {
+                    tabs.forEachIndexed { index, title ->
+                        Tab(
+                            text = { Text(title, color = MaterialTheme.colorScheme.primary) },
+                            selected = selectedTabIndex == index,
+                            onClick = { selectedTabIndex = index }
+                        )
+                    }
+                }
 
                 when (bookmarkedRecipes.value) {
                     is ProfileState.Error -> {}
@@ -113,27 +137,127 @@ fun ProfileScreen(
                     is ProfileState.Success -> {
                         val recipes =
                             (bookmarkedRecipes.value as ProfileState.Success).bookmarkedRecipes
-                        LazyVerticalStaggeredGrid(
-                            columns = StaggeredGridCells.Fixed(2),
-                            horizontalArrangement = Arrangement.spacedBy(4.dp),
-                            content = {
-                                itemsIndexed(recipes) { index, recipe ->
-                                    RecipeHorizontalListItem(
-                                        getLikesForRecipe = { viewmodel.getRecipeLike(it) },
-                                        recipe = recipe,
-                                        searchItem = true,
-                                        onRecipeClick = { onRecipeClick(it) },
-                                        onSave = { viewmodel.saveRecipe(it) }
-                                    )
+
+                        when (selectedTabIndex) {
+                            0 -> {
+                                SavedRecipeScreen(
+                                    recipes, viewmodel
+                                ) {
+                                    onRecipeClick(it)
                                 }
-                            },
-                        )
+                            }
+
+                            1 -> {
+                                ActivityScreen(
+                                    myRatings = emptyList(),
+                                    myTips = emptyList(),
+                                    getLikesForRecipe = { viewmodel.getRecipeLike(it) },
+                                    onRecipeClick = { onRecipeClick(it) },
+                                    onSave = { viewmodel.saveRecipe(it) }
+                                )
+                            }
+                        }
+
                     }
                 }
             }
         }
     }
+}
 
+@Composable
+fun SavedRecipeScreen(
+    recipes: List<Recipe>,
+    viewmodel: ProfileScreenViewModel,
+    onRecipeClick: (Int) -> Unit,
+) {
+    LazyVerticalStaggeredGrid(
+        columns = StaggeredGridCells.Fixed(2),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        content = {
+            itemsIndexed(recipes) { index, recipe ->
+                RecipeHorizontalListItem(
+                    getLikesForRecipe = { viewmodel.getRecipeLike(it) },
+                    recipe = recipe,
+                    searchItem = true,
+                    onRecipeClick = { onRecipeClick(it) },
+                    onSave = { viewmodel.saveRecipe(it) }
+                )
+            }
+        },
+    )
+}
+
+@Composable
+fun ActivityScreen(
+    myRatings: List<Recipe>,
+    myTips: List<Recipe>,
+    getLikesForRecipe: suspend (Int) -> Int,
+    onRecipeClick: (Int) -> Unit,
+    onSave: (Recipe) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        item {
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                HorizontalList(
+                    getLikesForRecipe = { getLikesForRecipe(it) },
+                    onRecipeClick = { },
+                    onSave = { },
+                    title = "My Ratings (${myRatings.size})",
+                    recipes = myRatings
+                )
+                if (myRatings.isEmpty()) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth().size(100.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Icon(
+                            tint = MaterialTheme.colorScheme.primary,
+                            imageVector = Icons.Default.ThumbUp,
+                            contentDescription = null
+                        )
+
+                        Text(
+                            fontSize = 12.sp,
+                            text = "Rate your first recipe to see it here."
+                        )
+                    }
+                }
+            }
+        }
+        item {
+            HorizontalList(
+                getLikesForRecipe = { getLikesForRecipe(it) },
+                onRecipeClick = { },
+                onSave = { },
+                title = "My Tips (${myTips.size})",
+                recipes = myTips
+            )
+            if (myTips.isEmpty()) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().size(100.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Icon(
+                        tint = MaterialTheme.colorScheme.primary,
+                        imageVector = Icons.Default.Book,
+                        contentDescription = null
+                    )
+
+                    Text(
+                        fontSize = 12.sp,
+                        text = "Leave your first tip to see it here."
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Preview


### PR DESCRIPTION
…activity screens

This commit introduces the following changes:

-   Added a TabRow to the profile screen to switch between "Saved Recipe" and "Activity" views.
-   Implemented `SavedRecipeScreen` to display bookmarked recipes using `LazyVerticalStaggeredGrid`.
-   Implemented `ActivityScreen` to display user activity (ratings and tips) using `LazyColumn` and `HorizontalList`.
-   Added placeholder UI for empty ratings and tips.
- Added Tabs functionality.
- Created Saved Recipe and Activity Screen.
- Removed old saved recipe list.
- Added rating and tips view in activity tab.