### PR TITLE
Remove environment ID masking from APK build workflow

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -77,7 +77,6 @@ jobs:
             echo "VERSION=${{ github.event.inputs.version }}"
           } >> local.properties
           
-          echo "::add-mask::$ENV_ID"
           echo "env_id=$ENV_ID" >> "$GITHUB_OUTPUT"
 
       - name: Build APK


### PR DESCRIPTION
Removed the `add-mask` command for `ENV_ID` in the `.github/workflows/build_apk.yml` file.