### PR TITLE
Add ID to local.properties generation step

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -50,6 +50,7 @@ jobs:
         run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > app/google-services.json
 
       - name: Generate local.properties
+        id: envsetup
         shell: bash
         run: |
           echo "sdk.dir=$ANDROID_HOME" > local.properties


### PR DESCRIPTION
Added `id: envsetup` to the "Generate local.properties" step in the build APK workflow.